### PR TITLE
Articles: add diff preview

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1235,6 +1235,9 @@ noscript span {
 .articles .article {
   cursor: pointer;
 }
+.articles #sidebar .text-container {
+  padding-right: 21px;
+}
 .articles .art-meta {
   text-align: center;
 }
@@ -1271,6 +1274,25 @@ noscript span {
 }
 .articles #sidebar .gotomod {
   font-size: 1.1em;
+}
+.articles .art-preview {
+  position: absolute;
+  width: 8px;
+  top: 73px;
+  right: 19px;
+  bottom: 13px;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: stretch;
+  border: 1px solid #ccc;
+
+  visibility: hidden;
+}
+.articles .art-preview .ins {
+  background-color: #8f8;
+}
+.articles .art-preview .del {
+  background-color: #f88;
 }
 /********************************* Amendements *******************************/
 .amendements #probe {

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1275,6 +1275,7 @@ noscript span {
   left: 0;
   right: 0;
   bottom: 0;
+  pointer-events: none;
 }
 .articles #sidebar .gotomod {
   font-size: 1.1em;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1235,9 +1235,6 @@ noscript span {
 .articles .article {
   cursor: pointer;
 }
-.articles #sidebar .text-container {
-  padding-right: 21px;
-}
 .articles .art-meta {
   text-align: center;
 }
@@ -1275,23 +1272,38 @@ noscript span {
 .articles #sidebar .gotomod {
   font-size: 1.1em;
 }
-.articles .art-preview {
+.articles #sidebar.has-diff-preview .text-container {
+  /* Hide scrollbar */
+  right: -100px;
+  padding-right: 113px;
+}
+.articles .diff-preview {
   position: absolute;
-  width: 8px;
-  top: 73px;
-  right: 19px;
-  bottom: 13px;
+  width: 13px;
+  top: 60px;
+  right: 0;
+  bottom: 0;
   display: flex;
   flex-flow: column nowrap;
   align-items: stretch;
-  border: 1px solid #ccc;
-
+  border-left: 1px solid #ccc;
   visibility: hidden;
 }
-.articles .art-preview .ins {
+.articles .has-diff-preview .diff-preview {
+  visibility: visible;
+}
+.articles .diff-preview .cursor {
+  position: absolute;
+  left: 0;
+  right: 0;
+  background-color: black;
+  opacity: 0.25;
+  cursor: pointer;
+}
+.articles .diff-preview .ins {
   background-color: #8f8;
 }
-.articles .art-preview .del {
+.articles .diff-preview .del {
   background-color: #f88;
 }
 /********************************* Amendements *******************************/

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1269,6 +1269,13 @@ noscript span {
   color: #fff;
   border-radius: 0;
 }
+.articles #sidebar #load_art {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
 .articles #sidebar .gotomod {
   font-size: 1.1em;
 }
@@ -1276,6 +1283,12 @@ noscript span {
   /* Hide scrollbar */
   right: -100px;
   padding-right: 113px;
+}
+.articles #sidebar.readmode.has-diff-preview .gotomod a.button {
+  right: 113px;
+}
+.articles #sidebar.has-diff-preview #load_art {
+  right: 100px;
 }
 .articles .diff-preview {
   position: absolute;

--- a/public/modules/articles/articles.html
+++ b/public/modules/articles/articles.html
@@ -34,12 +34,12 @@
     </div>
 
     <h4 id="text-title">ARTICLES</h4>
-    <div class="art-preview"></div>
     <div class="text-container">
       <div class="art-meta"></div>
       <div id="load_art"></div>
       <div class="art-txt"></div>
     </div>
+    <div class="diff-preview"></div>
   </div>
 
 <script type="text/javascript" src="lib/google-diff-match-patch-r106.min.js"></script>

--- a/public/modules/articles/articles.html
+++ b/public/modules/articles/articles.html
@@ -34,6 +34,7 @@
     </div>
 
     <h4 id="text-title">ARTICLES</h4>
+    <div class="art-preview"></div>
     <div class="text-container">
       <div class="art-meta"></div>
       <div id="load_art"></div>

--- a/public/modules/articles/articles.js
+++ b/public/modules/articles/articles.js
@@ -87,6 +87,7 @@ function ($rootScope, api) {
 
             function initCursor() {
                 var first = !$cursor;
+                if ($cursor) $cursor.remove();
 
                 $cursor = $('<div class="cursor">')
                 $diffPreview.append($cursor);
@@ -123,7 +124,7 @@ function ($rootScope, api) {
                     var pointer = e.originalEvent && e.originalEvent.changedTouches && e.originalEvent.changedTouches[0] || e;
                     startY = pointer.clientY;
 
-                    contentHeight = $(".art-meta").height() + $(".art-txt").height() + vMargins;
+                    contentHeight = $(".art-meta").height() + $(".art-txt").height();
                     containerHeight = $textContainer.height() + vMargins;
                     availableHeight = containerHeight - vMargins;
 
@@ -159,7 +160,7 @@ function ($rootScope, api) {
             function updateCursor(articleReloaded) {
                 if (!hasDiff) return;
 
-                var contentHeight = $(".art-meta").height() + $(".art-txt").height() + vMargins;
+                var contentHeight = $(".art-meta").height() + $(".art-txt").height();
 
                 var containerHeight = $textContainer.height() + vMargins;
                 var availableHeight = containerHeight - vMargins;

--- a/public/modules/articles/articles.js
+++ b/public/modules/articles/articles.js
@@ -59,8 +59,16 @@ function ($rootScope, api) {
             $scope.update_revs_view = function () {
                 var d = d3.select('#viz .curr').data()[0];
                 if ($scope.revs) {
+                    if (d.diffPreview) {
+                        $(".art-preview").css({visibility:'visible'});
+                        $(".art-preview").html(d.diffPreview).animate({opacity: 1}, 350);
+                    } else {
+                        $(".art-preview").css({visibility:'hidden'});
+                    }
+
                     $(".art-txt").html(d.textDiff).animate({opacity: 1}, 350);
                 } else {
+                    $(".art-preview").css({visibility:'hidden'});
                     $(".art-txt").html(d.originalText).animate({opacity: 1}, 350);
                 }
             };

--- a/public/modules/articles/articles.js
+++ b/public/modules/articles/articles.js
@@ -166,9 +166,12 @@ function ($rootScope, api) {
                 });
             }
 
-
             $textContainer.on("scroll", updateCursor);
             $(window).on("resize", updateCursor);
+
+            $scope.$watch("read", function() {
+                setTimeout(updateCursor, 500);
+            });
         }
     };
 }]);

--- a/public/modules/articles/articles.js
+++ b/public/modules/articles/articles.js
@@ -152,6 +152,12 @@ function ($rootScope, api) {
                 var containerHeight = $textContainer.height() + vMargins;
                 var availableHeight = containerHeight - vMargins;
 
+                if (contentHeight < availableHeight) {
+                    $("#sidebar").removeClass("has-diff-preview");
+                } else {
+                    $("#sidebar").addClass("has-diff-preview");
+                }
+
                 var scrollTop = $textContainer.scrollTop();
                 var cursorHeight = containerHeight * availableHeight / contentHeight;
                 var cursorTop = (containerHeight - cursorHeight) * scrollTop / (contentHeight - availableHeight);

--- a/public/modules/articles/articles.viz.js
+++ b/public/modules/articles/articles.viz.js
@@ -837,7 +837,7 @@ var valign, stacked, articlesScope, aligned = true;
                                             .replace(/\s+([:»;\?!%€])/g, '&nbsp;$1');
                                         d.textDiff += "</li></ul>";
 
-                                        if (d.status !== 'new' && d.status !== 'sup')
+                                        if (d.status !== 'new' && d.status !== 'sup' && d.n_diff !== 0)
                                             d.diffPreview = diff_preview(diff);
                                     } else d.textDiff += d.originalText;
 

--- a/public/modules/articles/articles.viz.js
+++ b/public/modules/articles/articles.viz.js
@@ -836,7 +836,9 @@ var valign, stacked, articlesScope, aligned = true;
                                         d.textDiff += diff_to_html(diff)
                                             .replace(/\s+([:»;\?!%€])/g, '&nbsp;$1');
                                         d.textDiff += "</li></ul>";
-                                        d.diffPreview = diff_preview(diff);
+
+                                        if (d.status !== 'new' && d.status !== 'sup')
+                                            d.diffPreview = diff_preview(diff);
                                     } else d.textDiff += d.originalText;
 
                                     thelawfactory.utils.spinner.stop(articlesScope.update_revs_view, 'load_art');

--- a/public/modules/articles/articles.viz.js
+++ b/public/modules/articles/articles.viz.js
@@ -89,6 +89,22 @@ var valign, stacked, articlesScope, aligned = true;
             }
         }
 
+        function diff_preview(diffs) {
+            var html = [];
+            var cls = {
+                '0': 'id',
+                '1': 'ins',
+                '-1': 'del'
+            };
+
+            diffs.forEach(function(d) {
+                var size = d[1].length;
+                html.push('<div class="preview-item ' + cls[d[0]] + '" style="flex-grow:'  + size + '; flex-shrink:' + size + ';"></div>');
+            });
+
+            return html.join('');
+        }
+
         function diff_to_html(diffs) {
             var html = [];
             for (var x = 0; x < diffs.length; x++) {
@@ -820,6 +836,7 @@ var valign, stacked, articlesScope, aligned = true;
                                         d.textDiff += diff_to_html(diff)
                                             .replace(/\s+([:»;\?!%€])/g, '&nbsp;$1');
                                         d.textDiff += "</li></ul>";
+                                        d.diffPreview = diff_preview(diff);
                                     } else d.textDiff += d.originalText;
 
                                     thelawfactory.utils.spinner.stop(articlesScope.update_revs_view, 'load_art');

--- a/public/modules/common/readMode.js
+++ b/public/modules/common/readMode.js
@@ -4,29 +4,29 @@ angular.module('theLawFactory')
 .directive('readMode', ['$location', function($location) {
     return {
         restrict: 'A',
-        controller: function($scope) {
-            $scope.read = $location.search()['read'] === '1';
+        controller: function($rootScope, $scope) {
+            $rootScope.read = $location.search()['read'] === '1';
 
-            $scope.readmode = function () {
+            $rootScope.readmode = function () {
                 $("#sidebar").addClass('readmode');
                 if ($scope.mod === 'amendements') {
                     $location.replace();
                     $location.search('read', '1');
                 }
-                $scope.read = true;
+                $rootScope.read = true;
             };
 
-            $scope.viewmode = function () {
+            $rootScope.viewmode = function () {
                 $("#sidebar").removeClass('readmode');
                 if ($scope.mod === 'amendements') {
                     $location.replace();
                     $location.search('read', null);
                 }
-                $scope.read = false;
+                $rootScope.read = false;
             };
 
-            if ($scope.read) {
-                $scope.readmode();
+            if ($rootScope.read) {
+                $rootScope.readmode();
             }
         }
     }


### PR DESCRIPTION
This PR is a proof-of-concept for article diff preview. It is only a graphical thing for now.
- There is no click interaction, maybe not necessary as the scrollbar is right next to it
- Maybe add click interaction, hide scrollbar and replace it with an indicator of the current position on the preview
- Maybe short articles should not show the preview (however there's no "clean" way of doing that, we either have to set a size threshold that will nearly always be wrong, or dynamically look for overflow)
- There are still some cases where it does not behave correctly (added/removed articles, should be easy to handle)
- We should handle colorblind-mode, too, with a different set of colors (red vs blue for example)

I don't want to get further into it without having reviews on the idea :)

Tell me how you feel about it, here's how it looks:
![preview](https://framapic.org/Y6KKoAR27AWr/YvCXeoFahza8.png)
