### PR TITLE
Remplacement de amd-fade par amd-opacity

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1476,6 +1476,34 @@ noscript span {
   background-image: url(../img/fade-down.png);
   background-repeat: repeat-x;
 }
+
+.amendements .amd-flex .amd-expand-symbol {
+    display:none;
+    color: #888;
+}
+
+/* The fading effect hides the title (e.g. 'Signataires', 'Texte', 'Exposé des
+   motifs') when the resolution is low. When needed, it is replaced by a '[...]'
+   text */
+
+@media (max-height:869px) {
+    .amendements .amd-flex .expanded .amd-expand-symbol {
+	display:none;
+    }
+    .amendements .amd-flex .amd-expand-symbol {
+	display:inline;
+    }
+    .amendements .amd-flex .amd-text-content,
+    .amendements .amd-flex .amd-fade {
+	display: none;
+    }
+
+    .amendements .amd-flex .expanded .amd-text-content {
+	display: block;
+    }
+
+}
+
 .amendements .amd-flex .expanded .amd-fade {
   display: none;
 }

--- a/public/modules/amendements/amendements.html
+++ b/public/modules/amendements/amendements.html
@@ -182,17 +182,20 @@
           <span>{{ selectedAmdtData.sujet }}</span>
         </div>
         <div class="amd-signataires {{ amdtExpanded === 'signataires' ? 'expanded' : '' }}" ng-click="setExpanded('signataires')">
-          <b>Signataires :</b>
+          <b>Signataires</b>
+          <div class='amd-expand-symbol'><span class="glyphicon glyphicon-plus-sign"></span></div>
           <div class="amd-text-content">{{ selectedAmdtData.signataires }}</div>
           <div class="amd-fade"></div>
         </div>
         <div class="amd-motifs {{ amdtExpanded === 'motifs' ? 'expanded' : '' }}" ng-click="setExpanded('motifs')">
-          <b>Exposé des motifs :</b>
+          <b>Exposé des motifs</b>
+          <div class='amd-expand-symbol'><span class="glyphicon glyphicon-plus-sign"></div>
           <div class="amd-text-content" ng-bind-html="selectedAmdtData.trustedExpose"></div>
           <div class="amd-fade"></div>
         </div>
         <div class="amd-text {{ amdtExpanded === 'text' ? 'expanded' : '' }}" ng-click="setExpanded('text')">
-          <b>Texte :</b>
+          <b>Texte</b>
+          <div class='amd-expand-symbol'><span class="glyphicon glyphicon-plus-sign"></div>
           <div class="amd-text-content" ng-bind-html="selectedAmdtData.trustedTexte"></div>
           <div class="amd-fade"></div>
         </div>


### PR DESCRIPTION
L'effet courant de 'fading' pour les sections [Signataires/Exposé des
motifs/Texte] rend le titre des sections assez illisible.

    https://www.lafabriquedelaloi.fr/amendements.html?loi=ppl13-007&etape=09_nouv.lect._assemblee_hemicycle&amdt=30

Pour améliorer ça tout en signifiant à l'utilisateur que ces sections sont à
développer (quand on clique dessus), l'effet est remplacé par une simple
opacité. Les ':' en fin de ligne insistent sur le message graphique qu'il y a
effectivement quelquechose à développer.