### PR TITLE
Fix year filtering #190

### DIFF
--- a/public/modules/navettes/navettes.viz.js
+++ b/public/modules/navettes/navettes.viz.js
@@ -429,9 +429,8 @@ reset_filters();
                         hashYears[y1] = true;
                     });
                     allYears[0] = "Toutes années";
-                    var ihashYear, hashYearsLen = hashYears.length;
-                    for (ihashYear = 0; ihashYear < hashYearsLen; ++ihashYear) {
-                        allYears.push(ihashYear);
+                    for (var year in hashYears) {
+                        allYears.push(year);
                     }
                     allYears.sort();
                     allYears.reverse();


### PR DESCRIPTION
`hashYears.length` would return `undefined` and then the loop wouldn't enter. I'm curious about how this code could work before :thinking: 

![image](https://user-images.githubusercontent.com/1469823/29441121-3cb2b4f8-83c9-11e7-9b96-e5aa67c759d4.png)
