### PR TITLE
Fix overflow of homepage texts titles

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -572,7 +572,7 @@ noscript span {
 #home #homelinks li {
   background-color: #fff;
   margin: 13px;
-  height: 94px;
+  min-height: 94px;
   display: flex;
   align-items: stretch;
   flex-flow: column nowrap;


### PR DESCRIPTION
The problem with fixed-height is that is can overflow sometimes (especially for AN-only texts):

![image](https://user-images.githubusercontent.com/1469823/49749274-1e6d8780-fca8-11e8-966f-6432c2f35575.png)

With this fix:

![image](https://user-images.githubusercontent.com/1469823/49791263-63d59780-fd30-11e8-9a44-9984460c71fe.png)

Most of the time the boxes should be aligned except when we have a text like this one

Other solutions:

  - Frontend text ellipsis like we do on the articles view: Not doable for multiple line without [crazy css](http://hackingui.com/front-end/a-pure-css-solution-for-multiline-text-truncation/) or JS but doable
  - Shorten the title when generating the data (`short_title = text_ellipsis(long_title) if len(short_title) > 100`)